### PR TITLE
PR: Add configurable week start and flexible label rendering modes

### DIFF
--- a/src/components/CalendarHeatmapPanel.tsx
+++ b/src/components/CalendarHeatmapPanel.tsx
@@ -2,41 +2,96 @@ import React, { useMemo } from 'react';
 import { PanelProps } from '@grafana/data';
 import { useTheme2, Tooltip } from '@grafana/ui';
 import HeatMap from '@uiw/react-heat-map';
-import { CalendarHeatmapOptions } from '../types';
+import { CalendarHeatmapOptions, HeatmapValue } from '../types';
 import { processTimeSeriesData, getColorPalette } from '../utils/dataProcessor';
 import { css } from '@emotion/css';
 import { t } from '@grafana/i18n';
 
 interface Props extends PanelProps<CalendarHeatmapOptions> {}
 
-export const CalendarHeatmapPanel: React.FC<Props> = ({
-  data,
-  width,
-  height,
-  options,
-  timeRange,
-}) => {
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * DAY_MS);
+}
+
+/**
+ * Parse either YYYY/MM/DD or YYYY-MM-DD into a local Date(y, m-1, d)
+ */
+function parseAnyYMD(dateStr: string): Date | null {
+  const s = String(dateStr).trim();
+  const parts = s.includes('/') ? s.split('/') : s.includes('-') ? s.split('-') : [];
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [y, m, d] = parts.map((x) => Number(x));
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
+    return null;
+  }
+
+  return new Date(y, m - 1, d);
+}
+
+/**
+ * Must match dataProcessor.ts formatDate(): YYYY/MM/DD
+ */
+function toKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}/${month}/${day}`;
+}
+
+export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, options, timeRange }) => {
   const theme = useTheme2();
 
-  // Process data from Grafana data source
   const heatmapData = useMemo(() => {
     return processTimeSeriesData(data.series, options.aggregation);
   }, [data.series, options.aggregation]);
 
-  // Calculate date range from Grafana time picker
-  const startDate = useMemo(() => new Date(timeRange.from.valueOf()), [timeRange.from]);
-  const endDate = useMemo(() => new Date(timeRange.to.valueOf()), [timeRange.to]);
+  const countByOriginalDate = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const d of heatmapData) {
+      m.set(d.date, d.count); // keys are YYYY/MM/DD from dataProcessor.ts
+    }
+    return m;
+  }, [heatmapData]);
+
+  const rawStartDate = useMemo(() => new Date(timeRange.from.valueOf()), [timeRange.from]);
+  const rawEndDate = useMemo(() => new Date(timeRange.to.valueOf()), [timeRange.to]);
 
   const availableWidth = useMemo(() => Math.max(0, width - 32), [width]);
 
+  // Monday-first: shift render dates by -1 day (rotates rows so Sunday becomes last)
+  const renderShiftDays = options.weekStart === 'monday' ? -1 : 0;
+
+  const shiftedStartDate = useMemo(() => addDays(rawStartDate, renderShiftDays), [rawStartDate, renderShiftDays]);
+  const shiftedEndDate = useMemo(() => addDays(rawEndDate, renderShiftDays), [rawEndDate, renderShiftDays]);
+
+  const shiftedHeatmapData: HeatmapValue[] = useMemo(() => {
+    if (renderShiftDays === 0) {
+      return heatmapData;
+    }
+
+    return heatmapData.map((d) => {
+      const dt = parseAnyYMD(d.date); // d.date is YYYY/MM/DD, but this supports both
+      if (!dt) {
+        return d;
+      }
+      const shifted = addDays(dt, renderShiftDays);
+      return { date: toKey(shifted), count: d.count }; // keep YYYY/MM/DD
+    });
+  }, [heatmapData, renderShiftDays]);
+
   const weekCount = useMemo(() => {
-    const alignedStart = !startDate.getDay()
-      ? startDate
-      : new Date(startDate.getTime() - startDate.getDay() * 24 * 60 * 60 * 1000);
-    const end = endDate;
-    const diffDays = Math.max(0, Math.floor((end.getTime() - alignedStart.getTime()) / (24 * 60 * 60 * 1000)));
+    const alignedStart = !shiftedStartDate.getDay()
+      ? shiftedStartDate
+      : new Date(shiftedStartDate.getTime() - shiftedStartDate.getDay() * DAY_MS);
+
+    const diffDays = Math.max(0, Math.floor((shiftedEndDate.getTime() - alignedStart.getTime()) / DAY_MS));
     return Math.max(1, Math.ceil((diffDays + 1) / 7));
-  }, [startDate, endDate]);
+  }, [shiftedStartDate, shiftedEndDate]);
 
   const computedRectSize = useMemo(() => {
     if (!options.autoRectSize) {
@@ -49,20 +104,43 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({
     return Math.max(4, Math.min(24, raw));
   }, [options.autoRectSize, options.rectSize, options.showWeekLabels, options.space, availableWidth, weekCount]);
 
-  // Calculate max value for legend
+  const weekLabels = useMemo(() => {
+    if (!options.showWeekLabels) {
+      return false as const;
+    }
+
+    return options.weekStart === 'monday'
+      ? [
+          t('panel.component.weekLabels.mon', 'Mon'),
+          t('panel.component.weekLabels.tue', 'Tue'),
+          t('panel.component.weekLabels.wed', 'Wed'),
+          t('panel.component.weekLabels.thu', 'Thu'),
+          t('panel.component.weekLabels.fri', 'Fri'),
+          t('panel.component.weekLabels.sat', 'Sat'),
+          t('panel.component.weekLabels.sun', 'Sun'),
+        ]
+      : [
+          t('panel.component.weekLabels.sun', 'Sun'),
+          t('panel.component.weekLabels.mon', 'Mon'),
+          t('panel.component.weekLabels.tue', 'Tue'),
+          t('panel.component.weekLabels.wed', 'Wed'),
+          t('panel.component.weekLabels.thu', 'Thu'),
+          t('panel.component.weekLabels.fri', 'Fri'),
+          t('panel.component.weekLabels.sat', 'Sat'),
+        ];
+  }, [options.showWeekLabels, options.weekStart]);
+
   const maxValue = useMemo(() => {
     if (heatmapData.length === 0) {
-        return 0;
+      return 0;
     }
-    return Math.max(...heatmapData.map(d => d.count));
+    return Math.max(...heatmapData.map((d) => d.count));
   }, [heatmapData]);
 
-  // Get color palette based on selected scheme
   const colors = useMemo(() => {
     return getColorPalette(options.colorScheme, theme, maxValue);
   }, [options.colorScheme, theme, maxValue]);
 
-  // Styles
   const styles = {
     container: css`
       width: 100%;
@@ -75,17 +153,14 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({
       padding: 16px;
     `,
     heatmap: css`
-      /* @uiw/react-heat-map sets inline color: var(--rhm-text-color, ...) */
       --rhm-text-color: ${theme.colors.text.secondary};
 
-      /* Weekday labels */
       .w-heatmap-week {
         font-size: 11px;
         font-weight: 600;
         fill: currentColor;
       }
 
-      /* Month labels have no class, but include a data-size attribute */
       text[data-size] {
         font-size: 12px;
         font-weight: 600;
@@ -111,7 +186,6 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({
     `,
   };
 
-  // Handle empty data
   if (data.series.length === 0) {
     return (
       <div className={styles.container}>
@@ -124,43 +198,54 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({
     <div className={styles.container}>
       <HeatMap
         className={styles.heatmap}
-        value={heatmapData}
-        startDate={startDate}
-        endDate={endDate}
+        value={shiftedHeatmapData}
+        startDate={shiftedStartDate}
+        endDate={shiftedEndDate}
         width={availableWidth}
         height={height - 80}
         rectSize={computedRectSize}
         space={options.space}
         radius={options.radius}
-        legendCellSize={0} // We'll render custom legend
-        weekLabels={options.showWeekLabels ? [
-          t('panel.component.weekLabels.sun', 'Sun'),
-          t('panel.component.weekLabels.mon', 'Mon'),
-          t('panel.component.weekLabels.tue', 'Tue'),
-          t('panel.component.weekLabels.wed', 'Wed'),
-          t('panel.component.weekLabels.thu', 'Thu'),
-          t('panel.component.weekLabels.fri', 'Fri'),
-          t('panel.component.weekLabels.sat', 'Sat'),
-        ] : false}
-        monthLabels={options.showMonthLabels ? [
-          t('panel.component.monthLabels.jan', 'Jan'),
-          t('panel.component.monthLabels.feb', 'Feb'),
-          t('panel.component.monthLabels.mar', 'Mar'),
-          t('panel.component.monthLabels.apr', 'Apr'),
-          t('panel.component.monthLabels.may', 'May'),
-          t('panel.component.monthLabels.jun', 'Jun'),
-          t('panel.component.monthLabels.jul', 'Jul'),
-          t('panel.component.monthLabels.aug', 'Aug'),
-          t('panel.component.monthLabels.sep', 'Sep'),
-          t('panel.component.monthLabels.oct', 'Oct'),
-          t('panel.component.monthLabels.nov', 'Nov'),
-          t('panel.component.monthLabels.dec', 'Dec'),
-        ] : false}
+        legendCellSize={0}
+        weekLabels={weekLabels}
+        monthLabels={
+          options.showMonthLabels
+            ? [
+                t('panel.component.monthLabels.jan', 'Jan'),
+                t('panel.component.monthLabels.feb', 'Feb'),
+                t('panel.component.monthLabels.mar', 'Mar'),
+                t('panel.component.monthLabels.apr', 'Apr'),
+                t('panel.component.monthLabels.may', 'May'),
+                t('panel.component.monthLabels.jun', 'Jun'),
+                t('panel.component.monthLabels.jul', 'Jul'),
+                t('panel.component.monthLabels.aug', 'Aug'),
+                t('panel.component.monthLabels.sep', 'Sep'),
+                t('panel.component.monthLabels.oct', 'Oct'),
+                t('panel.component.monthLabels.nov', 'Nov'),
+                t('panel.component.monthLabels.dec', 'Dec'),
+              ]
+            : false
+        }
         panelColors={colors}
-        rectRender={(props, data) => {
-          const tooltipContent = data.count !== undefined 
-            ? `${data.date}: ${data.count.toLocaleString()}`
-            : `${data.date}: ${t('panel.component.tooltip.noData', 'No data')}`;
+        rectRender={(props, cell) => {
+          // Convert rendered cell date back to original date for correct tooltip/value
+          const renderedDate = parseAnyYMD(cell.date);
+          let originalKey = String(cell.date);
+
+          if (renderedDate) {
+            const originalDate = addDays(renderedDate, -renderShiftDays); // reverse shift
+            originalKey = toKey(originalDate);
+          } else {
+            // If parse fails, at least try to normalize separators
+            originalKey = String(cell.date).replace(/-/g, '/');
+          }
+
+          const originalCount = countByOriginalDate.get(originalKey);
+
+          const tooltipContent =
+            originalCount !== undefined
+              ? `${originalKey}: ${originalCount.toLocaleString()}`
+              : `${originalKey}: ${t('panel.component.tooltip.noData', 'No data')}`;
 
           if (!options.showTooltip) {
             return <rect {...props} rx={options.radius} />;
@@ -182,17 +267,22 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({
             .filter(([key]) => !Number.isNaN(key) && key !== 1)
             .sort(([a], [b]) => a - b)
             .map(([key, color]) => (
-            <div
-              key={key}
-              className={styles.legendRect}
-              style={{ backgroundColor: color }}
-              title={t('panel.component.legend.tooltip', 'Level {{level}}', { level: key })}
-            />
+              <div
+                key={key}
+                className={styles.legendRect}
+                style={{ backgroundColor: color }}
+                title={t('panel.component.legend.tooltip', 'Level {{level}}', { level: key })}
+              />
             ))}
           <span>{t('panel.component.legend.more', 'More')}</span>
-          {maxValue > 0 && <span style={{ marginLeft: 8 }}>({t('panel.component.legend.max', 'Max')}: {maxValue.toLocaleString()})</span>}
+          {maxValue > 0 && (
+            <span style={{ marginLeft: 8 }}>
+              ({t('panel.component.legend.max', 'Max')}: {maxValue.toLocaleString()})
+            </span>
+          )}
         </div>
       )}
     </div>
   );
 };
+

--- a/src/components/CalendarHeatmapPanel.tsx
+++ b/src/components/CalendarHeatmapPanel.tsx
@@ -15,32 +15,43 @@ function addDays(date: Date, days: number): Date {
   return new Date(date.getTime() + days * DAY_MS);
 }
 
-/**
- * Parse either YYYY/MM/DD or YYYY-MM-DD into a local Date(y, m-1, d)
- */
+/** Parse either YYYY/MM/DD or YYYY-MM-DD */
 function parseAnyYMD(dateStr: string): Date | null {
   const s = String(dateStr).trim();
   const parts = s.includes('/') ? s.split('/') : s.includes('-') ? s.split('-') : [];
   if (parts.length !== 3) {
     return null;
   }
-
   const [y, m, d] = parts.map((x) => Number(x));
   if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
     return null;
   }
-
   return new Date(y, m - 1, d);
 }
 
-/**
- * Must match dataProcessor.ts formatDate(): YYYY/MM/DD
- */
+/** Must match dataProcessor.ts formatDate(): YYYY/MM/DD */
 function toKey(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}/${month}/${day}`;
+}
+
+function splitCsv(input: string): string[] {
+  return String(input)
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function rotateWeek(labelsSunFirst: string[], weekStart: 'sunday' | 'monday'): string[] {
+  // Input is always Sun..Sat
+  if (labelsSunFirst.length !== 7) {
+    return labelsSunFirst;
+  }
+  return weekStart === 'monday'
+    ? [...labelsSunFirst.slice(1), labelsSunFirst[0]] // Mon..Sat + Sun
+    : labelsSunFirst; // Sun..Sat
 }
 
 export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, options, timeRange }) => {
@@ -53,7 +64,7 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, opt
   const countByOriginalDate = useMemo(() => {
     const m = new Map<string, number>();
     for (const d of heatmapData) {
-      m.set(d.date, d.count); // keys are YYYY/MM/DD from dataProcessor.ts
+      m.set(d.date, d.count); // keys are YYYY/MM/DD
     }
     return m;
   }, [heatmapData]);
@@ -63,7 +74,7 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, opt
 
   const availableWidth = useMemo(() => Math.max(0, width - 32), [width]);
 
-  // Monday-first: shift render dates by -1 day (rotates rows so Sunday becomes last)
+  // Monday-first: shift render dates by -1 day to rotate weekday rows so Sunday becomes last
   const renderShiftDays = options.weekStart === 'monday' ? -1 : 0;
 
   const shiftedStartDate = useMemo(() => addDays(rawStartDate, renderShiftDays), [rawStartDate, renderShiftDays]);
@@ -75,12 +86,12 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, opt
     }
 
     return heatmapData.map((d) => {
-      const dt = parseAnyYMD(d.date); // d.date is YYYY/MM/DD, but this supports both
+      const dt = parseAnyYMD(d.date);
       if (!dt) {
         return d;
       }
       const shifted = addDays(dt, renderShiftDays);
-      return { date: toKey(shifted), count: d.count }; // keep YYYY/MM/DD
+      return { date: toKey(shifted), count: d.count };
     });
   }, [heatmapData, renderShiftDays]);
 
@@ -109,26 +120,72 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, opt
       return false as const;
     }
 
-    return options.weekStart === 'monday'
-      ? [
-          t('panel.component.weekLabels.mon', 'Mon'),
-          t('panel.component.weekLabels.tue', 'Tue'),
-          t('panel.component.weekLabels.wed', 'Wed'),
-          t('panel.component.weekLabels.thu', 'Thu'),
-          t('panel.component.weekLabels.fri', 'Fri'),
-          t('panel.component.weekLabels.sat', 'Sat'),
-          t('panel.component.weekLabels.sun', 'Sun'),
-        ]
-      : [
-          t('panel.component.weekLabels.sun', 'Sun'),
-          t('panel.component.weekLabels.mon', 'Mon'),
-          t('panel.component.weekLabels.tue', 'Tue'),
-          t('panel.component.weekLabels.wed', 'Wed'),
-          t('panel.component.weekLabels.thu', 'Thu'),
-          t('panel.component.weekLabels.fri', 'Fri'),
-          t('panel.component.weekLabels.sat', 'Sat'),
-        ];
-  }, [options.showWeekLabels, options.weekStart]);
+    // 1) Build base labels in Sun..Sat order
+    let labelsSunFirst: string[] | null = null;
+
+    if (options.weekLabelMode === 'number') {
+      // Sun..Sat => 1..7 (then rotate by weekStart)
+      labelsSunFirst = ['1', '2', '3', '4', '5', '6', '7'];
+    } else if (options.weekLabelMode === 'custom') {
+      const custom = splitCsv(options.weekLabelCustom);
+      labelsSunFirst = custom.length === 7 ? custom : null;
+    }
+
+    if (!labelsSunFirst) {
+      // default (Sun..Sat)
+      labelsSunFirst = [
+        t('panel.component.weekLabels.sun', 'Sun'),
+        t('panel.component.weekLabels.mon', 'Mon'),
+        t('panel.component.weekLabels.tue', 'Tue'),
+        t('panel.component.weekLabels.wed', 'Wed'),
+        t('panel.component.weekLabels.thu', 'Thu'),
+        t('panel.component.weekLabels.fri', 'Fri'),
+        t('panel.component.weekLabels.sat', 'Sat'),
+      ];
+    }
+
+    // 2) Rotate for weekStart (Monday-first => Mon..Sun)
+    return rotateWeek(labelsSunFirst, options.weekStart);
+  }, [
+    options.showWeekLabels,
+    options.weekStart,
+    options.weekLabelMode,
+    options.weekLabelCustom,
+  ]);
+
+  const monthLabels = useMemo(() => {
+    if (!options.showMonthLabels) {
+      return false as const;
+    }
+
+    if (options.monthLabelMode === 'number') {
+      return ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
+    }
+
+    if (options.monthLabelMode === 'custom') {
+      const custom = splitCsv(options.monthLabelCustom);
+      if (custom.length === 12) {
+        return custom;
+      }
+      // fall through to default if invalid
+    }
+
+    // default
+    return [
+      t('panel.component.monthLabels.jan', 'Jan'),
+      t('panel.component.monthLabels.feb', 'Feb'),
+      t('panel.component.monthLabels.mar', 'Mar'),
+      t('panel.component.monthLabels.apr', 'Apr'),
+      t('panel.component.monthLabels.may', 'May'),
+      t('panel.component.monthLabels.jun', 'Jun'),
+      t('panel.component.monthLabels.jul', 'Jul'),
+      t('panel.component.monthLabels.aug', 'Aug'),
+      t('panel.component.monthLabels.sep', 'Sep'),
+      t('panel.component.monthLabels.oct', 'Oct'),
+      t('panel.component.monthLabels.nov', 'Nov'),
+      t('panel.component.monthLabels.dec', 'Dec'),
+    ];
+  }, [options.showMonthLabels, options.monthLabelMode, options.monthLabelCustom]);
 
   const maxValue = useMemo(() => {
     if (heatmapData.length === 0) {
@@ -208,24 +265,7 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, opt
         radius={options.radius}
         legendCellSize={0}
         weekLabels={weekLabels}
-        monthLabels={
-          options.showMonthLabels
-            ? [
-                t('panel.component.monthLabels.jan', 'Jan'),
-                t('panel.component.monthLabels.feb', 'Feb'),
-                t('panel.component.monthLabels.mar', 'Mar'),
-                t('panel.component.monthLabels.apr', 'Apr'),
-                t('panel.component.monthLabels.may', 'May'),
-                t('panel.component.monthLabels.jun', 'Jun'),
-                t('panel.component.monthLabels.jul', 'Jul'),
-                t('panel.component.monthLabels.aug', 'Aug'),
-                t('panel.component.monthLabels.sep', 'Sep'),
-                t('panel.component.monthLabels.oct', 'Oct'),
-                t('panel.component.monthLabels.nov', 'Nov'),
-                t('panel.component.monthLabels.dec', 'Dec'),
-              ]
-            : false
-        }
+        monthLabels={monthLabels}
         panelColors={colors}
         rectRender={(props, cell) => {
           // Convert rendered cell date back to original date for correct tooltip/value
@@ -236,7 +276,6 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, opt
             const originalDate = addDays(renderedDate, -renderShiftDays); // reverse shift
             originalKey = toKey(originalDate);
           } else {
-            // If parse fails, at least try to normalize separators
             originalKey = String(cell.date).replace(/-/g, '/');
           }
 
@@ -285,4 +324,3 @@ export const CalendarHeatmapPanel: React.FC<Props> = ({ data, width, height, opt
     </div>
   );
 };
-

--- a/src/module.ts
+++ b/src/module.ts
@@ -117,35 +117,75 @@ export const plugin = new PanelPlugin<CalendarHeatmapOptions>(
         },
       })
 
-// Start day of week setting (use radio to avoid select-focus issues)
-.addRadio({
-  path: 'weekStart',
-  name: t('panel.options.weekStart.name', 'Week starts on'),
-  description: t('panel.options.weekStart.description', 'Choose whether the week starts on Sunday or Monday'),
-  defaultValue: 'sunday',
-  category: ['Layout'],
-  settings: {
-    options: [
-      { value: 'sunday', label: t('panel.options.weekStart.options.sunday', 'Sunday') },
-      { value: 'monday', label: t('panel.options.weekStart.options.monday', 'Monday') },
-    ],
-  },
-})
+    // Start day of week setting (use radio to avoid select-focus issues)
+    .addRadio({
+      path: 'weekStart',
+      name: t('panel.options.weekStart.name', 'Week starts on'),
+      description: t('panel.options.weekStart.description', 'Choose whether the week starts on Sunday or Monday'),
+      defaultValue: 'sunday',
+      category: ['Layout'],
+      settings: {
+        options: [
+          { value: 'sunday', label: t('panel.options.weekStart.options.sunday', 'Sunday') },
+          { value: 'monday', label: t('panel.options.weekStart.options.monday', 'Monday') },
+        ],
+      },
+    })
 
-    //   // Start day of week setting
-    // .addSelect({
-    //   path: 'weekStart',
-    //   name: t('panel.options.weekStart.name', 'Week starts on'),
-    //   description: t('panel.options.weekStart.description', 'Choose whether the week starts on Sunday or Monday'),
-    //   defaultValue: 'sunday',
-    //   category: ['Layout'],
-    //   settings: {
-    //     options: [
-    //       { value: 'sunday', label: t('panel.options.weekStart.options.sunday', 'Sunday') },
-    //       { value: 'monday', label: t('panel.options.weekStart.options.monday', 'Monday') },
-    //     ],
-    //   },
-    // })
+      // Month label mode
+      .addRadio({
+        path: 'monthLabelMode',
+        name: t('panel.options.monthLabelMode.name', 'Month label mode'),
+        description: t('panel.options.monthLabelMode.description', 'How to render month labels'),
+        defaultValue: 'default',
+        category: ['Labels'],
+        settings: {
+          options: [
+            { value: 'default', label: t('panel.options.monthLabelMode.options.default', 'Default') },
+            { value: 'number', label: t('panel.options.monthLabelMode.options.number', 'Number') },
+            { value: 'custom', label: t('panel.options.monthLabelMode.options.custom', 'Custom') },
+          ],
+        },
+      })
+      .addTextInput({
+        path: 'monthLabelCustom',
+        name: t('panel.options.monthLabelCustom.name', 'Custom month labels'),
+        description: t(
+          'panel.options.monthLabelCustom.description',
+          'Comma-separated 12 labels, e.g. Jan,Feb,...,Dec or 01,02,...,12'
+        ),
+        defaultValue: 'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec',
+        category: ['Labels'],
+        showIf: (o) => o.monthLabelMode === 'custom',
+      })
+
+      // Week label mode
+      .addRadio({
+        path: 'weekLabelMode',
+        name: t('panel.options.weekLabelMode.name', 'Week label mode'),
+        description: t('panel.options.weekLabelMode.description', 'How to render week day labels'),
+        defaultValue: 'default',
+        category: ['Labels'],
+        settings: {
+          options: [
+            { value: 'default', label: t('panel.options.weekLabelMode.options.default', 'Default') },
+            { value: 'number', label: t('panel.options.weekLabelMode.options.number', 'Number') },
+            { value: 'custom', label: t('panel.options.weekLabelMode.options.custom', 'Custom') },
+          ],
+        },
+      })
+      
+      .addTextInput({
+        path: 'weekLabelCustom',
+        name: t('panel.options.weekLabelCustom.name', 'Custom week labels'),
+        description: t(
+          'panel.options.weekLabelCustom.description',
+          'Comma-separated 7 labels, e.g. Sun,Mon,...,Sat or 1,2,...,7'
+        ),
+        defaultValue: 'Sun,Mon,Tue,Wed,Thu,Fri,Sat',
+        category: ['Labels'],
+        showIf: (o) => o.weekLabelMode === 'custom',
+      })
 
       // Interaction
       .addBooleanSwitch({

--- a/src/module.ts
+++ b/src/module.ts
@@ -117,6 +117,36 @@ export const plugin = new PanelPlugin<CalendarHeatmapOptions>(
         },
       })
 
+// Start day of week setting (use radio to avoid select-focus issues)
+.addRadio({
+  path: 'weekStart',
+  name: t('panel.options.weekStart.name', 'Week starts on'),
+  description: t('panel.options.weekStart.description', 'Choose whether the week starts on Sunday or Monday'),
+  defaultValue: 'sunday',
+  category: ['Layout'],
+  settings: {
+    options: [
+      { value: 'sunday', label: t('panel.options.weekStart.options.sunday', 'Sunday') },
+      { value: 'monday', label: t('panel.options.weekStart.options.monday', 'Monday') },
+    ],
+  },
+})
+
+    //   // Start day of week setting
+    // .addSelect({
+    //   path: 'weekStart',
+    //   name: t('panel.options.weekStart.name', 'Week starts on'),
+    //   description: t('panel.options.weekStart.description', 'Choose whether the week starts on Sunday or Monday'),
+    //   defaultValue: 'sunday',
+    //   category: ['Layout'],
+    //   settings: {
+    //     options: [
+    //       { value: 'sunday', label: t('panel.options.weekStart.options.sunday', 'Sunday') },
+    //       { value: 'monday', label: t('panel.options.weekStart.options.monday', 'Monday') },
+    //     ],
+    //   },
+    // })
+
       // Interaction
       .addBooleanSwitch({
         path: 'showTooltip',

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,10 @@ export interface CalendarHeatmapOptions {
   showWeekLabels: boolean;
   showMonthLabels: boolean;
   showLegend: boolean;
-  
+
+  /** Start day of week for layout/labels */
+  weekStart: 'sunday' | 'monday';
+
   // Data
   aggregation: 'sum' | 'count' | 'avg' | 'max' | 'min';
   
@@ -25,3 +28,4 @@ export interface HeatmapValue {
   date: string;
   count: number;
 }
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,24 +2,36 @@ export interface CalendarHeatmapOptions {
   // Colors
   colorScheme: 'green' | 'blue' | 'red' | 'yellow' | 'purple' | 'orange';
   emptyColor: string;
-  
+
   // Layout
   autoRectSize: boolean;
   rectSize: number;
   space: number;
   radius: number;
-  
+
   // Labels
   showWeekLabels: boolean;
   showMonthLabels: boolean;
   showLegend: boolean;
 
-  /** Start day of week for layout/labels */
+  // Week start
   weekStart: 'sunday' | 'monday';
+
+  /**
+   * Label display modes:
+   * - default: use localized short names (Oct/Nov, Tue/Sun)
+   * - number: use numbers (months 01..12, weekdays 1..7)
+   * - custom: user provides labels
+   */
+  monthLabelMode: 'default' | 'number' | 'custom';
+  monthLabelCustom: string; // comma-separated 12 labels
+
+  weekLabelMode: 'default' | 'number' | 'custom';
+  weekLabelCustom: string; // comma-separated 7 labels
 
   // Data
   aggregation: 'sum' | 'count' | 'avg' | 'max' | 'min';
-  
+
   // Interaction
   showTooltip: boolean;
 }
@@ -28,4 +40,3 @@ export interface HeatmapValue {
   date: string;
   count: number;
 }
-


### PR DESCRIPTION
Closes: #13

# Summary

This PR adds configurable **week start day** and flexible **label rendering modes** to the Calendar Heatmap Panel.

Users can now:
- Switch the **week start** between **Sunday** (default) and **Monday**
- Choose how **month labels** are displayed: **Default**, **Number (01–12)**, or **Custom**
- Choose how **weekday labels** are displayed: **Default**, **Number (1–7)**, or **Custom**

The implementation ensures the heatmap grid layout updates correctly when switching week start day, while keeping tooltip date/value mapping accurate.

---

# Changes

## 1) Week start day option (Sunday / Monday)
- Adds a new panel option to control the start of the week.
- Uses a **RadioGroup** (instead of a dropdown) to avoid the focus/blur issue seen with Select controls in the panel options UI.
- Updates the heatmap layout so that:
  - **Sunday-first**: Sunday is the first row (current behavior)
  - **Monday-first**: Sunday becomes the last row and Monday becomes the first row
- Fixes tooltip consistency so that the displayed date always matches the original aggregated data for that day.

## 2) Month labels: Default / Number / Custom
- Adds a RadioGroup with three options:
  1. **Default**: keep current month labels (e.g. Oct, Nov)
  2. **Number**: display numeric month labels (01–12)
  3. **Custom**: user-defined labels (comma-separated 12 values)

## 3) Weekday labels: Default / Number / Custom
- Adds a RadioGroup with three options:
  1. **Default**: keep current weekday labels (e.g. Tue, Sun)
  2. **Number**: display weekday labels as numbers (1–7)
  3. **Custom**: user-defined labels (comma-separated 7 values)
- Custom weekday labels are interpreted as **Sun..Sat** input and rotated automatically when week start is Monday.

---

# Files changed

- `src/components/CalendarHeatmapPanel.tsx`
  - Implements Monday-first layout behavior while preserving tooltip correctness
  - Generates month/week labels based on the selected label modes

- `src/module.ts`
  - Adds RadioGroup options for week start, month label mode, and weekday label mode
  - Adds conditional text inputs for custom label lists

- `src/types.ts`
  - Extends `CalendarHeatmapOptions` with:
    - `weekStart`
    - `monthLabelMode`, `monthLabelCustom`
    - `weekLabelMode`, `weekLabelCustom`

---

# Usage notes

## Custom month labels
- Provide **12** comma-separated labels.
- Example:
  - `01,02,03,04,05,06,07,08,09,10,11,12`

## Custom weekday labels
- Provide **7** comma-separated labels in **Sun,Mon,Tue,Wed,Thu,Fri,Sat** order.
- Example:
  - `Sun,Mon,Tue,Wed,Thu,Fri,Sat`
- When week start is set to Monday, the display order will rotate automatically (Mon..Sun).

---

# Testing

Manual verification in Grafana:
- Toggle **Week starts on** between Sunday and Monday:
  - Verify the grid row order changes accordingly
  - Verify tooltip dates/values continue to match the underlying day aggregation
- Toggle **Month label mode**:
  - Default: Oct/Nov style remains
  - Number: shows 01..12
  - Custom: shows provided 12-label list
- Toggle **Week label mode**:
  - Default: Tue/Sun style remains
  - Number: shows 1..7
  - Custom: shows provided 7-label list and rotates with week start setting